### PR TITLE
Oppgraderer Distroless til nodejs18-debian12@sha256:ee36c135

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM gcr.io/distroless/nodejs18-debian12@sha256:ee36c135f8391f1facc373d9e9c0445fde06b0ab45c514ef33b84163fe7ec14b
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
Fra flex-cli